### PR TITLE
Feat: Show css references

### DIFF
--- a/src/components/code/box.tsx
+++ b/src/components/code/box.tsx
@@ -4,6 +4,7 @@ import { CodeDescBox } from "./desc/box";
 import { CodeOverviewBox } from "./overview/box";
 import { CodeTextBoxClient } from "./text/box-client";
 import { CodeTextBoxServer } from "./text/box-server";
+import { Source } from "./source";
 
 const column = "flex-1 lt960:w-full lt960:flex-none";
 const desc = "pl-72 lt1280:pl-36 lt960:pl-0 lt960:pt-36";
@@ -19,6 +20,8 @@ export function CodeBox(props: { feature: Feature }): ReactElement {
         <Suspense fallback={<CodeTextBoxServer feature={feature} />}>
           <CodeTextBoxClient feature={feature} />
         </Suspense>
+        <div className="mt-36" />
+        <Source feature={feature} />
       </div>
       <div className={`${column} ${desc}`}>
         <CodeDescBox feature={feature} />

--- a/src/components/code/source.tsx
+++ b/src/components/code/source.tsx
@@ -1,0 +1,34 @@
+import { Feature } from "features";
+
+interface Props {
+  feature: Feature;
+}
+
+export function Source({ feature }: Props) {
+  const [attribute, value] = feature.css.split(": ");
+
+  if (!attribute || !value)
+    throw new Error(`unexpected syntax: ${feature.css}`);
+
+  return (
+    <>
+      <div className="mb-18">
+        To use{" "}
+        <strong className="font-semibold">{`${feature.name} (${feature.code})`}</strong>{" "}
+        in CSS:
+      </div>
+      <div className="p-24 lt960:p-18 bg-EDF relative shadow-E2E rounded">
+        <code>
+          <span className="text-718">{attribute}: </span>
+          <span className="text-2D3">{value}</span>
+        </code>
+        <button
+          className="absolute right-0 bottom-0 px-9 bg-FFF rounded-ss text-15 italic text-718"
+          onClick={() => navigator.clipboard.writeText(feature.css)}
+        >
+          Copy code
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/features.ts
+++ b/src/features.ts
@@ -13,6 +13,7 @@ export interface Feature {
   type: "digit" | "letter",
   default?: boolean,
   required?: string,
+  css: string,
 };
 
 export const featureMap: { [code: string]: Feature | undefined } = {
@@ -27,6 +28,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: tabular-nums;",
   },
   pnum: {
     code: "pnum",
@@ -39,6 +41,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: proportional-nums;",
   },
   onum: {
     code: "onum",
@@ -53,6 +56,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/alternate-figures.html#oldstyle-figures"
     ],
     type: "digit",
+    css: "font-variant-numeric: oldstyle-nums;",
   },
   lnum: {
     code: "lnum",
@@ -65,6 +69,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/lining-figures",
     ],
     type: "digit",
+    css: "font-variant-numeric: lining-nums;",
   },
   ordn: {
     code: "ordn",
@@ -78,6 +83,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://practicaltypography.com/ordinals.html",
     ],
     type: "digit",
+    css: "font-variant-numeric: ordinal;",
   },
   frac: {
     code: "frac",
@@ -90,6 +96,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/numbers/fractions",
     ],
     type: "digit",
+    css: "font-variant-numeric: diagonal-fractions;",
   },
   zero: {
     code: "zero",
@@ -100,6 +107,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     related: [],
     references: [],
     type: "digit",
+    css: "font-variant-numeric: slashed-zero;",
   },
   liga: {
     code: "liga",
@@ -114,6 +122,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     ],
     type: "letter",
     default: true,
+    css: "font-variant-ligatures: common-ligatures;",
   },
   calt: {
     code: "calt",
@@ -125,6 +134,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
+    css: "font-variant-ligatures: contextual;",
   },
   hist: {
     code: "hist",
@@ -138,6 +148,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Long_s",
     ],
     type: "letter",
+    css: 'font-feature-settings: "hist";',
   },
   hlig: {
     code: "hlig",
@@ -148,7 +159,8 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     related: ["liga", "dlig", "hist"],
     references: [],
     type: "letter",
-    required: '"hist"'
+    required: '"hist"',
+    css: "font-variant-ligatures: historical-ligatures;",
   },
   dlig: {
     code: "dlig",
@@ -161,6 +173,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-3/signs-and-symbols/ligatures-2"
     ],
     type: "letter",
+    css: "font-variant-ligatures: discretionary-ligatures;",
   },
   salt: {
     code: "salt",
@@ -176,6 +189,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/I#Forms_and_variants",
     ],
     type: "letter",
+    css: 'font-feature-settings: "salt";',
   },
   swsh: {
     code: "swsh",
@@ -189,6 +203,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://en.wikipedia.org/wiki/Swash_(typography)",
     ],
     type: "letter",
+    css: 'font-feature-settings: "swsh";',
   },
   smcp: {
     code: "smcp",
@@ -202,6 +217,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
       "https://www.fonts.com/content/learning/fontology/level-1/type-anatomy/small-caps",
     ],
     type: "letter",
+    css: "font-variant-caps: small-caps;",
   },
   rand: {
     code: "rand",
@@ -214,6 +230,7 @@ export const featureMap: { [code: string]: Feature | undefined } = {
     references: [],
     type: "letter",
     default: true,
+    css: 'font-feature-settings: "calt"',
   },
 };
 


### PR DESCRIPTION
### Description

Add CSS references with a copy code button for easy use

### Reference

https://github.com/thien-do/otf/issues/9

### Test

<img width="1280" alt="SCR-20240730-ulzh" src="https://github.com/user-attachments/assets/5b34c48a-49cf-41f6-86b2-9577cb32b108">
<img width="1280" alt="SCR-20240730-umeh" src="https://github.com/user-attachments/assets/da8af076-9e93-4762-9ef1-5b1339a10b5a">
